### PR TITLE
Fix task counter

### DIFF
--- a/kubernetes/deploy.go
+++ b/kubernetes/deploy.go
@@ -472,6 +472,7 @@ func (k8sDeployment *KubernetesDeployment) deployServices() error {
 				return fmt.Errorf("Unable to find node id %s in cluster", mapping.Id)
 			}
 
+			originalFamily := family
 			count, ok := taskCount[family]
 			if !ok {
 				count = 1
@@ -487,7 +488,7 @@ func (k8sDeployment *KubernetesDeployment) deployServices() error {
 				deploySpec.Spec.Selector.MatchLabels = newLabels
 				deploySpec.Spec.Template.GetObjectMeta().SetLabels(newLabels)
 			}
-			taskCount[family] = count
+			taskCount[originalFamily] = count
 
 			// Assigning Pods to Nodes
 			nodeSelector := map[string]string{}


### PR DESCRIPTION
The task counter was behaving weirdly, somehow always fails when deploying multiple deployments with a same name.

Figured out that it was because it didn't really count the number (using the original unmodified family name)