### PR TITLE
Fix Issue#40. Show kubeconfig and ssh download buttons only for available deployments

### DIFF
--- a/ui/cluster.html
+++ b/ui/cluster.html
@@ -3,11 +3,8 @@
 
 <head>
     <title>Deployer</title>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css">
-    <link rel="stylesheet" type="text/css" href="/static/css/font-awesome.min.css">
-    <link rel="stylesheet" type="text/css" href="/static/css/jquery.loadmask.css">
-    <script src="/static/js/jquery-3.2.0.min.js"></script>
-    <script src="/static/js/common.js"></script>
+    <link rel="import" href="/static/common/linkCss.html">
+    <link rel="import" href="/static/common/linkJs.html">
     <script>
         $(function() {
             $('.deployment-list li').click(function() {
@@ -180,7 +177,7 @@
                                     if (container.resources.limits) {
                                         nodesDetails.push('<div class="data-labels">Limits:</div>');
                                         appendAttrs(nodesDetails, container.resources.limits);
-                                    }                                   
+                                    }
                                     nodesDetails.push('</div>');
                                 });
                                 nodesDetails.push('</div>');
@@ -342,7 +339,7 @@
             <a href="/ui" class="banner">Deployer</a>
             <ul>
                 <li>
-                    <a href="/ui">deploys</a>
+                    <a href="/ui">deployments</a>
                 </li>
                 <li>
                     <a href="/ui/clusters" class="active">clusters</a>

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,10 +3,7 @@
 
 <head>
 <title>Deployer</title>
-<link rel="stylesheet" type="text/css" href="/static/css/style.css">
-<link rel="stylesheet" type="text/css" href="/static/css/font-awesome.min.css">
-<link rel="stylesheet" type="text/css" href="/static/css/jquery.loadmask.css">
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<link rel="import" href="/static/common/linkCss.html">
 </head>
 
 <body>
@@ -65,37 +62,28 @@
         </div>
     </main>
 </body>
-<script src="/static/js/jquery-3.2.0.min.js"></script>
+<link rel="import" href="/static/common/linkJs.html">
 <script src="/static/js/download.js"></script>
 <script src="/static/js/jquery.loadmask.min.js"></script>
-<script src="/static/js/common.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <script>
   var runningInterval = null;
-
   $(function() {
     var realHeight = $('.deployment-list').height();
     $(".deployment-list").css('height', (realHeight + 100) + 'px');
-
     $('ul.nav-tabs a').on('click', function(event) {
       event.preventDefault();
       $('ul.nav-tabs li').removeClass('active');
       $(this).parent().addClass('active');
+      if ($(this).data('status') !== 'Running') {
+        $('.deployment-btn').hide();
+      }
       refreshUI($(this).data('status'));
     });
-
     $('.deployment-list').on('click', 'li', function() {
       $('.deployment-list li').removeClass('active');
       $(this).addClass('active');
-
-      $('main h1').remove();
-      $('.deployment-detail').show();
-
-      getDeploymentLogContent($(this).data('name'));
-
-      if ($(this).data('status') == 'Deleted') {
-        $('.deployment-btn').hide();
-      } else {
+      if ($('ul.nav-tabs li').first().hasClass('active')) {
         $('.deployment-btn').show();
         if ($(this).data('type') == 'K8S') {
           $('#downloadKubeconfigBtn').show();
@@ -103,8 +91,10 @@
           $('#downloadKubeconfigBtn').hide();
         }
       }
+      $('main h1').remove();
+      $('.deployment-detail').show();
+      getDeploymentLogContent($(this).data('name'));
     });
-
     $('#deleteBtn').click(function() {
       var logFileName = $('.deployment-list .active').data('name');
       var deploymentName = logFileName.replace('.log', '');
@@ -126,7 +116,6 @@
         });
       }
     });
-
     $('#downloadSshKeyBtn').click(function() {
       var deploymentName = $('.deployment-list .active').data('name').replace('.log', '');
       $.ajax({
@@ -134,7 +123,6 @@
         success: download.bind(true, 'text/plain', deploymentName + '-key')
       });
     });
-
     $('#downloadKubeconfigBtn').click(function() {
       var deploymentName = $('.deployment-list .active').data('name').replace('.log', '');
       $.ajax({
@@ -142,10 +130,8 @@
         success: download.bind(true, 'text/plain', 'kubeconfig')
       });
     });
-
     refreshUI('Running');
   });
-
   function refreshUI(status) {
     clearInterval(runningInterval);
     runningInterval = setInterval(function fetchLog(){
@@ -162,13 +148,11 @@
               }
               $(this).remove();
             });
-
             $.each(json.data, function(index, element) {
               let deployment = $( '#deploymentTemplate' ).clone();
               if (activeDeployment && element.Name === activeDeployment) {
                 deployment.addClass('active');
               }
-
               deployment.attr('data-name', element.Name);
               deployment.attr('data-type', element.Type);
               deployment.attr('data-status', element.Status);
@@ -180,7 +164,6 @@
               deployment.insertAfter('li.deployment:last');
             })
           }
-
           if (status === 'Running') {
             let active = $('ul.deployment-list li[class~="active"]').get(0);
             if (active) {
@@ -191,13 +174,10 @@
           }
         }
       });
-
       return fetchLog;
     }(), 10000);
-
     $('.deployment-log').hide();
   };
-
   function getDeploymentLogContent(logFileName) {
     $.ajax({
       url: '/ui/logs/' + logFileName,

--- a/ui/static/common/linkCss.html
+++ b/ui/static/common/linkCss.html
@@ -1,0 +1,4 @@
+<link rel="stylesheet" type="text/css" href="/static/css/style.css">
+<link rel="stylesheet" type="text/css" href="/static/css/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="/static/css/jquery.loadmask.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">

--- a/ui/static/common/linkJs.html
+++ b/ui/static/common/linkJs.html
@@ -1,0 +1,2 @@
+<script src="/static/js/jquery-3.2.0.min.js"></script>
+<script src="/static/js/common.js"></script>

--- a/ui/static/css/style.css
+++ b/ui/static/css/style.css
@@ -9,7 +9,7 @@ header {
     position: fixed;
     top: 0;
     width: 100%;
-    background-color: #4A4A4A;
+    background-color: #286090;
     height: 65px;
 }
 
@@ -41,7 +41,7 @@ header nav ul {
 header nav li {
     font-size: 24px;
     line-height: 32px;
-    margin-righ: 24px;
+    margin-right: 24px;
     padding: 15px;
 }
 

--- a/ui/user.html
+++ b/ui/user.html
@@ -3,10 +3,8 @@
 
 <head>
     <title>Deployer</title>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css">
-    <link rel="stylesheet" type="text/css" href="/static/css/font-awesome.min.css">
-    <script src="/static/js/jquery-3.2.0.min.js"></script>
-    <script src="/static/js/common.js"></script>
+    <link rel="import" href="/static/common/linkCss.html">
+    <link rel="import" href="/static/common/linkJs.html">
     <script>
         var userInputHtml = '<input type="text"/>';
         var awsIdInputHtml = '<input type="text" size="25"/>';
@@ -174,7 +172,7 @@
         main {
             margin-left: 0%;
         }
-        
+
         .user-detail button {
             width: 90px;
         }
@@ -203,7 +201,7 @@
             <a href="/ui" class="banner">Deployer</a>
             <ul>
                 <li>
-                    <a href="/ui">deploys</a>
+                    <a href="/ui">deployments</a>
                 </li>
                 <li>
                     <a href="/ui/clusters">clusters</a>


### PR DESCRIPTION
Resolve #40 UI Issue

1. Revise that kubeconfig and ssh download buttons only are shown in
Running tab
2. Move included css and js links into common html for easier managing