### PR TITLE
Allow user to delete failed clusters

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -92,10 +92,6 @@
             event.preventDefault();
             $('ul.nav-tabs li').removeClass('active');
             $(this).parent().addClass('active');
-            if ($(this).data('status') !== 'Running') {
-                $('.deployment-btn').hide();
-            }
-
             $('.deployment-log').hide();
             refreshUI($(this).data('status'));
         });


### PR DESCRIPTION
Resolve #99 

1.filter not work has resolve by #89, because  share deployer has not yet been updated to a new version,  so it still does not seem to filter properly
2.Show delete button block, when fail deployment, user can click delete button delete clusters