### PR TITLE
Implement a new API endpoint to query the address of a service

### DIFF
--- a/apis/models.go
+++ b/apis/models.go
@@ -86,3 +86,9 @@ type Deployment struct {
 type IamRole struct {
 	PolicyDocument string `form:"policyDocument" json:"policyDocument"`
 }
+
+// ServiceAddress object that stores the information of service container
+type ServiceAddress struct {
+	Host string `bson:"host,omitempty" json:"host,omitempty"`
+	Port int32  `bson:"port,omitempty" json:"port,omitempty"`
+}

--- a/clustermanagers/awsecs/deploy.go
+++ b/clustermanagers/awsecs/deploy.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hyperpilotio/deployer/common"
 	"github.com/hyperpilotio/deployer/job"
 	"github.com/hyperpilotio/deployer/log"
-	"github.com/hyperpilotio/deployer/share"
 	logging "github.com/op/go-logging"
 	"github.com/spf13/viper"
 )
@@ -1430,7 +1429,7 @@ func (ecsDeployer *ECSDeployer) GetServiceUrl(serviceName string) (string, error
 	return nodeInfo.PublicDnsName + ":" + nodePort, nil
 }
 
-func (ecsDeployer *ECSDeployer) GetServiceAddress(serviceName string) (*share.ServiceAddress, error) {
+func (ecsDeployer *ECSDeployer) GetServiceAddress(serviceName string) (*apis.ServiceAddress, error) {
 	var nodePort int32
 	taskFamilyName := ""
 	for _, task := range ecsDeployer.Deployment.TaskDefinitions {
@@ -1464,7 +1463,7 @@ func (ecsDeployer *ECSDeployer) GetServiceAddress(serviceName string) (*share.Se
 		return nil, errors.New("Unable to find node in cluster")
 	}
 
-	return &share.ServiceAddress{Host: nodeInfo.PublicDnsName, Port: nodePort}, nil
+	return &apis.ServiceAddress{Host: nodeInfo.PublicDnsName, Port: nodePort}, nil
 }
 
 func (ecsDeployer *ECSDeployer) GetStoreInfo() interface{} {

--- a/clustermanagers/factory.go
+++ b/clustermanagers/factory.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hyperpilotio/deployer/clustermanagers/kubernetes"
 	"github.com/hyperpilotio/deployer/job"
 	"github.com/hyperpilotio/deployer/log"
-	"github.com/hyperpilotio/deployer/share"
 	"github.com/pborman/uuid"
 	"github.com/spf13/viper"
 )
@@ -29,7 +28,7 @@ type Deployer interface {
 	GetLog() *log.DeploymentLog
 	GetScheduler() *job.Scheduler
 	GetServiceUrl(serviceName string) (string, error)
-	GetServiceAddress(serviceName string) (*share.ServiceAddress, error)
+	GetServiceAddress(serviceName string) (*apis.ServiceAddress, error)
 	GetServiceMappings() (map[string]interface{}, error)
 }
 

--- a/clustermanagers/kubernetes/deploy.go
+++ b/clustermanagers/kubernetes/deploy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hyperpilotio/deployer/common"
 	"github.com/hyperpilotio/deployer/job"
 	"github.com/hyperpilotio/deployer/log"
-	"github.com/hyperpilotio/deployer/share"
 	logging "github.com/op/go-logging"
 	"github.com/spf13/viper"
 
@@ -1679,7 +1678,7 @@ func (k8sDeployer *K8SDeployer) findNodeIdFromServiceName(serviceName string) (i
 }
 
 // GetServiceAddress return ServiceAddress object
-func (k8sDeployer *K8SDeployer) GetServiceAddress(serviceName string) (*share.ServiceAddress, error) {
+func (k8sDeployer *K8SDeployer) GetServiceAddress(serviceName string) (*apis.ServiceAddress, error) {
 	k8sClient, err := k8s.NewForConfig(k8sDeployer.KubeConfig)
 	if err != nil {
 		return nil, errors.New("Unable to connect to Kubernetes during get service url: " + err.Error())
@@ -1695,7 +1694,7 @@ func (k8sDeployer *K8SDeployer) GetServiceAddress(serviceName string) (*share.Se
 			string(service.Spec.Type) == "LoadBalancer" {
 			port := service.Spec.Ports[0].Port
 			hostname := service.Status.LoadBalancer.Ingress[0].Hostname
-			address := &share.ServiceAddress{Host: hostname, Port: port}
+			address := &apis.ServiceAddress{Host: hostname, Port: port}
 
 			return address, nil
 		}

--- a/share/models.go
+++ b/share/models.go
@@ -1,7 +1,0 @@
-package share
-
-// ServiceAddress object that stores the information of service container
-type ServiceAddress struct {
-	Host string `bson:"host,omitempty" json:"host,omitempty"`
-	Port int32  `bson:"port,omitempty" json:"port,omitempty"`
-}


### PR DESCRIPTION
# WHY / WHAT

To provide an API endpoint that allows workload-profiler to query the address of a service.

* Implement `getServiceAddress` function

#### Ex: 
```
curl http://localhost:7777/v1/deployments/redis-D16994E8/services/redis-serve/address
```
#### Response
```
{"host":"a039b1ec4659811e787110a727c226ba-1798566361.us-east-1.elb.amazonaws.com","port":6379}
```
@tnachen 