### PR TITLE
Add EBS volume size

### DIFF
--- a/clustermanagers/kubernetes/in_deploy.go
+++ b/clustermanagers/kubernetes/in_deploy.go
@@ -232,12 +232,24 @@ func (deployer *InClusterK8SDeployer) setupEC2(
 		networkSpecs = append(networkSpecs, networkSpec)
 	}
 
+	blockDeviceMappings := []*ec2.BlockDeviceMapping{}
+	for _, mapping := range launchConfig.BlockDeviceMappings {
+		blockDeviceMappings = append(blockDeviceMappings, &ec2.BlockDeviceMapping{
+			DeviceName: mapping.DeviceName,
+			Ebs: &ec2.EbsBlockDevice{
+				VolumeSize: mapping.Ebs.VolumeSize,
+				VolumeType: mapping.Ebs.VolumeType,
+			},
+		})
+	}
+
 	nodeCount := len(deployer.Deployment.ClusterDefinition.Nodes)
 	for _, node := range deployer.Deployment.ClusterDefinition.Nodes {
 		runInstancesInput := &ec2.RunInstancesInput{
-			KeyName:      launchConfig.KeyName,
-			ImageId:      launchConfig.ImageId,
-			EbsOptimized: launchConfig.EbsOptimized,
+			KeyName:             launchConfig.KeyName,
+			ImageId:             launchConfig.ImageId,
+			BlockDeviceMappings: blockDeviceMappings,
+			EbsOptimized:        launchConfig.EbsOptimized,
 			Placement: &ec2.Placement{
 				AvailabilityZone: aws.String(""),
 			},


### PR DESCRIPTION
Add BlockDeviceMappings setting to ec2.RunInstancesInput, default  EBS volume size will reference kubernetes cloudformation DiskSizeGb param, now is 40GB. If there is not setting BlockDeviceMappings will all default 8GB size, will cause the hard disk space is not enough.
